### PR TITLE
Update logging + Reduce binance api call

### DIFF
--- a/price-oracle/priceprovider/subscription_test.go
+++ b/price-oracle/priceprovider/subscription_test.go
@@ -46,9 +46,11 @@ func TestStartSubscription(t *testing.T) {
 }
 
 func TestSubscriptionBinance(t *testing.T) {
-	binance := types.Binance{
-		Symbol: "ATOMUSDT",
-		Price:  "-50.0", // A value that is never possible in real world.
+	binance := []types.Binance{
+		{
+			Symbol: "ATOMUSDT",
+			Price:  "-50.0", // A value that is never possible in real world.
+		},
 	}
 
 	b, err := json.Marshal(binance)


### PR DESCRIPTION
_**1 rev enough since it's tested on staging + dev.**_

- Queries binance once to get **ALL tokens** from binance. And and get prices of whitelisted tokens from that response.
- Improve logging. Missing tokens are now grouped together and printed in a single line.
- Introduced logging when calling coingecko api.