### PR TITLE
fix: reduce sentry traces rate for bg tasks

### DIFF
--- a/cmd/price-oracle-server/main.go
+++ b/cmd/price-oracle-server/main.go
@@ -56,7 +56,7 @@ func main() {
 			sampleRate := cfg.SentryTracesSampleRate
 			switch ctx.Span.Op {
 			case "subscription", "aggregator":
-				sampleRate = sampleRate / 1000.
+				sampleRate /= 1000.
 			}
 			return sentry.UniformTracesSampler(sampleRate).Sample(ctx)
 		}),


### PR DESCRIPTION
Because of spamming